### PR TITLE
Rework of exposure of (asr) with fewer new names.

### DIFF
--- a/src/signed.ml
+++ b/src/signed.ml
@@ -8,7 +8,15 @@
 module Pervasives = Pervasives [@@ocaml.warning "-3"]
 
 module type S = sig
-  include Unsigned.Operations
+  type t
+
+  module Infix : sig
+    include Unsigned.Infix with type t := t
+    val (asr) : t -> int -> t
+  end
+
+  include Unsigned.S with type t := t
+                     with module Infix := Infix
 
   val neg : t -> t
   val abs : t -> t
@@ -19,12 +27,6 @@ module type S = sig
   val to_nativeint : t -> nativeint
   val of_int64 : int64 -> t
   val to_int64 : t -> int64
-
-  module Infix : sig
-    include Unsigned.Infixes with type t := t
-
-    val (asr) : t -> int -> t
-  end
 end
 
 module type Basics = sig

--- a/src/signed.mli
+++ b/src/signed.mli
@@ -14,7 +14,7 @@ module type S = sig
     include Unsigned.Infix with type t := t
 
     val (asr) : t -> int -> t
-    (** [x asr y] shifts [x] to the right by [y] bits.  See {!Int32.shift_right}. *)
+    (** [x asr y] shifts [x] to the right by [y] bits.  See {!shift_right}. *)
   end
 
   include Unsigned.S with type t := t

--- a/src/signed.mli
+++ b/src/signed.mli
@@ -8,7 +8,17 @@
 (** Types and operations for signed integers. *)
 
 module type S = sig
-  include Unsigned.Operations
+  type t
+
+  module Infix : sig
+    include Unsigned.Infix with type t := t
+
+    val (asr) : t -> int -> t
+    (** [x asr y] shifts [x] to the right by [y] bits.  See {!Int32.shift_right}. *)
+  end
+
+  include Unsigned.S with type t := t
+                     with module Infix := Infix
 
   val neg : t -> t
   (** Unary negation. *)
@@ -37,13 +47,6 @@ module type S = sig
 
   val to_int64 : t -> int64
   (** Convert the given signed integer to an int64 value. *)
-
-  module Infix : sig
-    include Unsigned.Infixes with type t := t
-
-    val (asr) : t -> int -> t
-    (** [x lsr y] shifts [x] to the right by [y] bits.  See {!shift_right}. *)
-  end
 end
 (** Signed integer operations *)
 

--- a/src/unsigned.ml
+++ b/src/unsigned.ml
@@ -64,12 +64,6 @@ module type Infix = sig
   val (lsr) : t -> int -> t
 end
 
-module type Operations = sig
-  include Basics
-  include Extras with type t := t
-end
-
-module type Infixes = Infix
 
 module type S = sig
   include Basics

--- a/src/unsigned.mli
+++ b/src/unsigned.mli
@@ -7,7 +7,43 @@
 
 (** Types and operations for unsigned integers. *)
 
-module type Operations = sig
+module type Infix = sig
+  type t
+
+  val (+) : t -> t -> t
+  (** Addition.  See {!add}. *)
+
+  val (-) : t -> t -> t
+  (** Subtraction.  See {!sub}.*)
+
+  val ( * ) : t -> t -> t
+  (** Multiplication.  See {!mul}.*)
+
+  val (/) : t -> t -> t
+  (** Division.  See {!div}.*)
+
+  val (mod) : t -> t -> t
+  (** Integer remainder.  See {!rem}. *)
+
+  val (land) : t -> t -> t
+  (** Bitwise logical and.  See {!logand}. *)
+
+  val (lor) : t -> t -> t
+  (** Bitwise logical or.  See {!logor}. *)
+
+  val (lxor) : t -> t -> t
+  (** Bitwise logical exclusive or.  See {!logxor}. *)
+
+  val (lsl) : t -> int -> t
+  (** [x lsl y] shifts [x] to the left by [y] bits.  See {!shift_left}. *)
+
+  val (lsr) : t -> int -> t
+  (** [x lsr y] shifts [x] to the right by [y] bits.  See {!shift_right}. *)
+end
+(** Infix names for the unsigned integer operations. *)
+
+
+module type S = sig
   type t
 
   val add : t -> t -> t
@@ -94,50 +130,10 @@ module type Operations = sig
 
   val pp : Format.formatter -> t -> unit
   (** Output the result of {!to_string} on a formatter. *)
+
+  module Infix : Infix with type t := t
 end
 (** Unsigned integer operations. *)
-
-module type Infixes = sig
-  type t
-
-  val (+) : t -> t -> t
-  (** Addition.  See {!add}. *)
-
-  val (-) : t -> t -> t
-  (** Subtraction.  See {!sub}.*)
-
-  val ( * ) : t -> t -> t
-  (** Multiplication.  See {!mul}.*)
-
-  val (/) : t -> t -> t
-  (** Division.  See {!div}.*)
-
-  val (mod) : t -> t -> t
-  (** Integer remainder.  See {!rem}. *)
-
-  val (land) : t -> t -> t
-  (** Bitwise logical and.  See {!logand}. *)
-
-  val (lor) : t -> t -> t
-  (** Bitwise logical or.  See {!logor}. *)
-
-  val (lxor) : t -> t -> t
-  (** Bitwise logical exclusive or.  See {!logxor}. *)
-
-  val (lsl) : t -> int -> t
-  (** [x lsl y] shifts [x] to the left by [y] bits.  See {!shift_left}. *)
-
-  val (lsr) : t -> int -> t
-  (** [x lsr y] shifts [x] to the right by [y] bits.  See {!shift_right}. *)
-end
-(** Infix names for the unsigned integer operations. *)
-
-module type S = sig
-  include Operations
-
-  module Infix : Infixes with type t := t
-end
-(** Unsigned integer operations and operators. *)
 
 module UChar : S with type t = private int
 (** Unsigned char type and operations. *)


### PR DESCRIPTION
This is a slight rework of ocamllabs/ocaml-integers#30 (which adds `(asr)` to the interface) that exposes fewer names.

Instead of adding new names `Operations` and `Infixes` to the `Unsigned` and `Signed` interface, this change instead just exposes the `Infix` module type.